### PR TITLE
Fix import error when using python3 Validate

### DIFF
--- a/avro_json_serializer/__init__.py
+++ b/avro_json_serializer/__init__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
 # (c) [2014] LinkedIn Corp. All rights reserved.
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
 
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 """
@@ -22,11 +22,14 @@ import avro.schema
 from avro.io import AvroTypeException
 import six
 
-if six.PY2:
+
+try:
     from avro.io import validate
-else:
+except ImportError:
     from avro.io import Validate as validate
-    basestring = str
+
+    if six.PY3:
+        basestring = str
 
 try:
     from collections import OrderedDict


### PR DESCRIPTION
**Describe the bug**
The 1.0.1 version of Avro Json serializer is trying to do an invalid import. The latest version of Avro (1.9.2 as of now) doesn't have any class called `Validate` which could be imported. As an assumption that it had a class back in time this PR is opened for fixing the import issue and correct the assumption about python3.

Side note: The line changes in the license note is only line ending character changes/fixes.

**To Reproduce**
Steps to reproduce the behavior:
1. `$ pip install avro avro-json-serializer`
2. `$ python3`
3. `>>> from avro_json_serializer import AvroJsonSerializer`

**Expected behavior**
A clear and concise description of what you expected to happen.

**System info**
 - OS: OSx
 - Avro version: 1.9.2
 - Python version 3.7

**Additional context**
The traceback raised during import:
```
  File "/Users/me/test_service/virtualenv/lib/python3.7/site-packages/avro_json_serializer/__init__.py", line 28, in <module>
    from avro.io import Validate as validate
ImportError: cannot import name 'Validate' from 'avro.io' (/Users/me/test_service/virtualenv/lib/python3.7/site-packages/avro/io.py)
```